### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,5 @@
   "license": "MIT",
   "devDependencies": {
     "react-native": "^0.11.4"
-  },
-  "peerDependencies": {
-    "react-native": ">=0.4.0 <1.0.0"
   }
 }


### PR DESCRIPTION
`peerDependencies` blocks `react-native` Release Candidate versions (eg. `0.19.0-rc`)
